### PR TITLE
Use direct BeatSaver download URL

### DIFF
--- a/src/components/challenge-setter.js
+++ b/src/components/challenge-setter.js
@@ -34,7 +34,8 @@ AFRAME.registerComponent('challenge-setter', {
 
   fetchZip: function (id, difficulty) {
     // Unzip.
-    const loader = new ZipLoader(`https://beatsaver.com/download/${id}`);
+    const [short] = id.split('-');
+    const loader = new ZipLoader(`https://beatsaver.com/storage/songs/${short}/${id}.zip`);
     loader.on('load', () => {
       let imageBlob;
       let songBlob;


### PR DESCRIPTION
Using `/download` will increment the download counter, which is not desirable for preview applications.